### PR TITLE
Domain verification of keys to be pushed

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The `config/development.js` file can be used to configure a local development in
 * HTTPS_UPGRADE=true                          (upgrade HTTP requests to HTTPS and use [HSTS](https://developer.mozilla.org/en-US/docs/Web/Security/HTTP_strict_transport_security))
 * HTTPS_KEY_PIN=base64_encoded_sha256         (optional, see [HPKP](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning))
 * HTTPS_KEY_PIN_BACKUP=base64_encoded_sha256  (optional, see [HPKP](https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning))
+* PUBLIC_KEY_DOMAIN_NAMES=example.com;sub.example.com
 
 
 

--- a/config/default.js
+++ b/config/default.js
@@ -41,7 +41,8 @@ module.exports = {
   },
 
   publicKey: {
-    purgeTimeInDays: process.env.PUBLIC_KEY_PURGE_TIME || 30
+    purgeTimeInDays: process.env.PUBLIC_KEY_PURGE_TIME || 30,
+    domainNames: process.env.PUBLIC_KEY_DOMAIN_NAMES.split(';'),
   }
 
 };

--- a/src/service/public-key.js
+++ b/src/service/public-key.js
@@ -86,7 +86,7 @@ class PublicKey {
 
     const last = array => array[array.length - 1];
     const domainNames = key.userIds.map(userId => last(userId.split('@')));
-    // if no email addresses are in the domain, an error will be thrown
+    // if no UID email address is in the domain, an error will be thrown
     if (!domainNames.some(domainName => config.publicKey.domainNames.includes(domainName))) {
       util.throw(403, 'You are not allowed to add your key');
     }

--- a/src/service/public-key.js
+++ b/src/service/public-key.js
@@ -86,7 +86,7 @@ class PublicKey {
 
     const last = array => array[array.length - 1];
     const domainNames = key.userIds.map(userId => last(userId.split('@')));
-    // if all email addresses are not in the domain, an error will be thrown
+    // if no email addresses are in the domain, an error will be thrown
     if (!domainNames.some(domainName => config.publicKey.domainNames.includes(domainName))) {
       util.throw(403, 'You are not allowed to add your key');
     }

--- a/src/service/public-key.js
+++ b/src/service/public-key.js
@@ -83,6 +83,14 @@ class PublicKey {
         util.throw(400, 'Provided email address does not match a valid user ID of the key');
       }
     }
+
+    const last = array => array[array.length - 1];
+    const domainNames = key.userIds.map(userId => last(userId.split('@')));
+    // if all email addresses are not in the domain, an error will be thrown
+    if (!domainNames.some(domainName => config.publicKey.domainNames.includes(domainName))) {
+      util.throw(403, 'You are not allowed to add your key');
+    }
+
     // check for existing verified key with same id
     const verified = await this.getVerified({keyId: key.keyId});
     if (verified) {


### PR DESCRIPTION
For example, in this organisation, members can have a mail address with `approvers.dev` domain name.
To operate a key server only for the members, we need to verify the key to be pushed has a user ID with the domain name.